### PR TITLE
商品情報編集機能

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -9,10 +9,10 @@ class ApplicationController < ActionController::Base
       username == 'admin' && password == '2222'
     end
 
-  def configure_permitted_parameters
-    devise_parameter_sanitizer.permit(
-      :sign_up, keys: [:nickname, :family_name, :first_name, :family_name_kana, :first_name_kana, :birth_date]
-    )
+    def configure_permitted_parameters
+      devise_parameter_sanitizer.permit(
+        :sign_up, keys: [:nickname, :family_name, :first_name, :family_name_kana, :first_name_kana, :birth_date]
+      )
+    end
   end
-end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,6 +23,11 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+
   private
 
   def item_params

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,6 @@
 class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
+  before_action :set_item, only: [:edit, :show, :update]
 
   def index
     @items = Item.order('created_at DESC')
@@ -19,16 +20,13 @@ class ItemsController < ApplicationController
   end
 
   def show
-    @item = Item.find(params[:id])
   end
 
   def edit
-    @item = Item.find(params[:id])
     redirect_to root_path unless current_user.id == @item.user.id
   end
 
   def update
-    @item = Item.find(params[:id])
     if @item.update(item_params)
       redirect_to item_path
     else
@@ -41,5 +39,9 @@ class ItemsController < ApplicationController
   def item_params
     params.require(:item).permit(:name, :introduction, :price, :item_condition_id, :preparation_day_id, :postage_payer_id, :category_id,
                                  :trading_status_id, :image).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -25,8 +25,16 @@ class ItemsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
-  end
+end
 
+  def update
+    @item = Item.find(params[:id])
+    if @item.update(item_params)
+      redirect_to item_path
+    else
+      render :edit
+    end
+  end
 
   private
 
@@ -34,5 +42,5 @@ class ItemsController < ApplicationController
     params.require(:item).permit(:name,:introduction,:price,:item_condition_id,:preparation_day_id,:postage_payer_id,:category_id,:trading_status_id,:image).merge(user_id: current_user.id)
 
   end
-
 end
+

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,8 +2,7 @@ class ItemsController < ApplicationController
   before_action :authenticate_user!, only: [:new, :edit]
 
   def index
-    @items = Item.order("created_at DESC")       
-    
+    @items = Item.order('created_at DESC')
   end
 
   def new
@@ -12,11 +11,11 @@ class ItemsController < ApplicationController
 
   def create
     @item = Item.new(item_params)
-   if @item.save
-    redirect_to root_path
-  else 
-    render :new
-  end
+    if @item.save
+      redirect_to root_path
+    else
+      render :new
+    end
   end
 
   def show
@@ -26,7 +25,7 @@ class ItemsController < ApplicationController
   def edit
     @item = Item.find(params[:id])
     redirect_to root_path unless current_user.id == @item.user.id
-end
+  end
 
   def update
     @item = Item.find(params[:id])
@@ -40,8 +39,7 @@ end
   private
 
   def item_params
-    params.require(:item).permit(:name,:introduction,:price,:item_condition_id,:preparation_day_id,:postage_payer_id,:category_id,:trading_status_id,:image).merge(user_id: current_user.id)
-
+    params.require(:item).permit(:name, :introduction, :price, :item_condition_id, :preparation_day_id, :postage_payer_id, :category_id,
+                                 :trading_status_id, :image).merge(user_id: current_user.id)
   end
 end
-

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,5 +1,5 @@
 class ItemsController < ApplicationController
-  before_action :authenticate_user!, only: [:new]
+  before_action :authenticate_user!, only: [:new, :edit]
 
   def index
     @items = Item.order("created_at DESC")       
@@ -25,6 +25,7 @@ class ItemsController < ApplicationController
 
   def edit
     @item = Item.find(params[:id])
+    redirect_to root_path unless current_user.id == @item.user.id
 end
 
   def update

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -1,18 +1,18 @@
-class Category< ActiveHash::Base
+class Category < ActiveHash::Base
   self.data = [
-    {id: 1, name: '---'},
-    {id: 2, name: 'レディース'},
-    {id: 3, name: 'メンズ'},
-    {id: 4, name: 'ベビー・キッズ'},
-    {id: 5, name: 'インテリア・住まい・小物'},
-    {id: 6, name: '本・音楽・ゲーム'},
-    {id: 7, name: 'おもちゃ・ホビー・グッズ'},
-    {id: 8, name: '家電・スマホ・カメラ'},
-    {id: 9, name: 'スポーツ・レジャー'},
-    {id: 10, name: 'ハンドメイド'},
-    {id: 11, name: 'その他'}
+    { id: 1, name: '---' },
+    { id: 2, name: 'レディース' },
+    { id: 3, name: 'メンズ' },
+    { id: 4, name: 'ベビー・キッズ' },
+    { id: 5, name: 'インテリア・住まい・小物' },
+    { id: 6, name: '本・音楽・ゲーム' },
+    { id: 7, name: 'おもちゃ・ホビー・グッズ' },
+    { id: 8, name: '家電・スマホ・カメラ' },
+    { id: 9, name: 'スポーツ・レジャー' },
+    { id: 10, name: 'ハンドメイド' },
+    { id: 11, name: 'その他' }
   ]
 
-    include ActiveHash::Associations
-    has_many :items
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,35 +1,36 @@
 class Item < ApplicationRecord
   extend ActiveHash::Associations::ActiveRecordExtensions
-belongs_to :item_condition
-belongs_to :preparation_day 
-belongs_to :postage_payer   
-belongs_to :category  
-belongs_to :trading_status
-has_one_attached :image
-has_one :purchase_history
-belongs_to :user
+  belongs_to :item_condition
+  belongs_to :preparation_day
+  belongs_to :postage_payer
+  belongs_to :category
+  belongs_to :trading_status
+  has_one_attached :image
+  has_one :purchase_history
+  belongs_to :user
 
-validates :item_condition_id, numericality: { other_than: 1 , message: "can't be blank"} 
-validates :preparation_day_id, numericality:  { other_than: 1 , message: "an't be blank"} 
-validates :postage_payer_id, numericality:  { other_than: 1 , message: "can't be blank"} 
-validates :category_id, numericality:  { other_than: 1 , message: "can't be blank"} 
-validates :trading_status_id, numericality:  { other_than: 1 , message: "can't be blank"} 
+  validates :item_condition_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :preparation_day_id, numericality:  { other_than: 1, message: "an't be blank" }
+  validates :postage_payer_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :category_id, numericality: { other_than: 1, message: "can't be blank" }
+  validates :trading_status_id, numericality:  { other_than: 1, message: "can't be blank" }
 
-validates :name,                   presence: true
-validates :introduction,           presence: true
-validates :price,                  format: { with: /\A[0-9]+\z/, message: 'Price is invalid. Input half-width characters' }
-validates :price,
-            numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999, message: 'Out of setting range' }
+  validates :name,                   presence: true
+  validates :introduction,           presence: true
+  validates :price,                  format: { with: /\A[0-9]+\z/, message: 'Price is invalid. Input half-width characters' }
+  validates :price,
+            numericality: { only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9_999_999,
+                            message: 'Out of setting range' }
 
-validates :image,                  presence: true
-validates :item_condition,         presence: true
-validates :preparation_day,        presence: true
-validates :postage_payer,          presence: true
-validates :category,               presence: true
-validates :trading_status,         presence: true
-validates :price,                  presence: true
+  validates :image,                  presence: true
+  validates :item_condition,         presence: true
+  validates :preparation_day,        presence: true
+  validates :postage_payer,          presence: true
+  validates :category,               presence: true
+  validates :trading_status,         presence: true
+  validates :price,                  presence: true
 
-def was_attached?
-  self.image.attached?
-end
+  def was_attached?
+    image.attached?
+  end
 end

--- a/app/models/item_condition.rb
+++ b/app/models/item_condition.rb
@@ -1,14 +1,14 @@
-class ItemCondition< ActiveHash::Base
+class ItemCondition < ActiveHash::Base
   self.data = [
-    {id: 1, name: '---'},
-    {id: 2, name: '新品・未使用'},
-    {id: 3, name: '未使用に近い'},
-    {id: 4, name: '目立った傷や汚れなし'},
-    {id: 5, name: 'やや傷や汚れあり'},
-    {id: 6, name: '傷や汚れあり'},
-    {id: 7, name: '全体的に状態が悪い'},
+    { id: 1, name: '---' },
+    { id: 2, name: '新品・未使用' },
+    { id: 3, name: '未使用に近い' },
+    { id: 4, name: '目立った傷や汚れなし' },
+    { id: 5, name: 'やや傷や汚れあり' },
+    { id: 6, name: '傷や汚れあり' },
+    { id: 7, name: '全体的に状態が悪い' }
   ]
 
-    include ActiveHash::Associations
-    has_many :items
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/postage_payer.rb
+++ b/app/models/postage_payer.rb
@@ -1,10 +1,10 @@
-class PostagePayer< ActiveHash::Base
+class PostagePayer < ActiveHash::Base
   self.data = [
-    {id: 1, name: '---'},
-    {id: 2, name: '着払い（購入者負担)'},
-    {id: 3, name: '送料込み（出品者負担)'},
+    { id: 1, name: '---' },
+    { id: 2, name: '着払い（購入者負担)' },
+    { id: 3, name: '送料込み（出品者負担)' }
   ]
 
-    include ActiveHash::Associations
-    has_many :items
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/preparation_day.rb
+++ b/app/models/preparation_day.rb
@@ -1,11 +1,11 @@
-class PreparationDay< ActiveHash::Base
+class PreparationDay < ActiveHash::Base
   self.data = [
-    {id: 1, name: '---'},
-    {id: 2, name: '１〜２日で発送'},
-    {id: 3, name: '２〜３日で発送'},
-    {id: 4, name: '４〜７日で発送'},
+    { id: 1, name: '---' },
+    { id: 2, name: '１〜２日で発送' },
+    { id: 3, name: '２〜３日で発送' },
+    { id: 4, name: '４〜７日で発送' }
   ]
 
-    include ActiveHash::Associations
-    has_many :items
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/models/trading_status.rb
+++ b/app/models/trading_status.rb
@@ -1,24 +1,24 @@
-class TradingStatus< ActiveHash::Base
+class TradingStatus < ActiveHash::Base
   self.data = [
-      {id: 1, name: '---'},
-      {id: 2, name: '北海道'}, {id: 3, name: '青森県'}, {id: 4, name: '岩手県'},
-      {id: 5, name: '宮城県'}, {id: 6, name: '秋田県'}, {id: 7, name: '山形県'},
-      {id: 8, name: '福島県'}, {id: 9, name: '茨城県'}, {id: 10, name: '栃木県'},
-      {id: 11, name: '群馬県'}, {id: 12, name: '埼玉県'}, {id: 13, name: '千葉県'},
-      {id: 14, name: '東京都'}, {id: 15, name: '神奈川県'}, {id: 16, name: '新潟県'},
-      {id: 17, name: '富山県'}, {id: 18, name: '石川県'}, {id: 19, name: '福井県'},
-      {id: 20, name: '山梨県'}, {id: 21, name: '長野県'}, {id: 22, name: '岐阜県'},
-      {id: 23, name: '静岡県'}, {id: 24, name: '愛知県'}, {id: 25, name: '三重県'},
-      {id: 26, name: '滋賀県'}, {id: 27, name: '京都府'}, {id: 28, name: '大阪府'},
-      {id: 29, name: '兵庫県'}, {id: 30, name: '奈良県'}, {id: 31, name: '和歌山県'},
-      {id: 32, name: '鳥取県'}, {id: 33, name: '島根県'}, {id: 34, name: '岡山県'},
-      {id: 35, name: '広島県'}, {id: 36, name: '山口県'}, {id: 37, name: '徳島県'},
-      {id: 38, name: '香川県'}, {id: 39, name: '愛媛県'}, {id: 40, name: '高知県'},
-      {id: 41, name: '福岡県'}, {id: 42, name: '佐賀県'}, {id: 43, name: '長崎県'},
-      {id: 44, name: '熊本県'}, {id: 45, name: '大分県'}, {id: 46, name: '宮崎県'},
-      {id: 47, name: '鹿児島県'}, {id: 48, name: '沖縄県'}
+    { id: 1, name: '---' },
+    { id: 2, name: '北海道' }, { id: 3, name: '青森県' }, { id: 4, name: '岩手県' },
+    { id: 5, name: '宮城県' }, { id: 6, name: '秋田県' }, { id: 7, name: '山形県' },
+    { id: 8, name: '福島県' }, { id: 9, name: '茨城県' }, { id: 10, name: '栃木県' },
+    { id: 11, name: '群馬県' }, { id: 12, name: '埼玉県' }, { id: 13, name: '千葉県' },
+    { id: 14, name: '東京都' }, { id: 15, name: '神奈川県' }, { id: 16, name: '新潟県' },
+    { id: 17, name: '富山県' }, { id: 18, name: '石川県' }, { id: 19, name: '福井県' },
+    { id: 20, name: '山梨県' }, { id: 21, name: '長野県' }, { id: 22, name: '岐阜県' },
+    { id: 23, name: '静岡県' }, { id: 24, name: '愛知県' }, { id: 25, name: '三重県' },
+    { id: 26, name: '滋賀県' }, { id: 27, name: '京都府' }, { id: 28, name: '大阪府' },
+    { id: 29, name: '兵庫県' }, { id: 30, name: '奈良県' }, { id: 31, name: '和歌山県' },
+    { id: 32, name: '鳥取県' }, { id: 33, name: '島根県' }, { id: 34, name: '岡山県' },
+    { id: 35, name: '広島県' }, { id: 36, name: '山口県' }, { id: 37, name: '徳島県' },
+    { id: 38, name: '香川県' }, { id: 39, name: '愛媛県' }, { id: 40, name: '高知県' },
+    { id: 41, name: '福岡県' }, { id: 42, name: '佐賀県' }, { id: 43, name: '長崎県' },
+    { id: 44, name: '熊本県' }, { id: 45, name: '大分県' }, { id: 46, name: '宮崎県' },
+    { id: 47, name: '鹿児島県' }, { id: 48, name: '沖縄県' }
   ]
 
-    include ActiveHash::Associations
-    has_many :items
+  include ActiveHash::Associations
+  has_many :items
 end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field @item.image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area @item.name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area @item.introduction, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,11 +7,8 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
-
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
+    <%= form_with(model: @item, local: true) do |f| %>
+    <%= render 'shared/error_messages', model: f.object %>
 
     <%# 商品画像 %>
     <div class="img-upload">
@@ -23,7 +20,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field @item.image, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +30,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area @item.name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area @item.introduction, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :introduction, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +49,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+         <%= f.collection_select(:category_id, Category.all, :id,:name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:item_condition_id, ItemCondition.all, :id,:name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +70,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:postage_payer_id, PostagePayer.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:trading_status_id, TradingStatus.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+         <%= f.collection_select(:preparation_day_id, PreparationDay.all, :id,:name,  {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +98,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +138,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -24,7 +24,7 @@
     </div>
     <% if user_signed_in? %>
       <% if current_user.id == @item.user_id %>
-        <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+        <%= link_to "商品の編集",  edit_item_path(@item.id) , method: :get, class: "item-red-btn" %>
         <p class="or-text">or</p>
         <%= link_to "削除", "#", method: :delete, class:"item-destroy" %>
       <% else %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show, :edit]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
   devise_for :users
   root to: 'items#index'
-  resources :items, only: [:index, :new, :create, :show]
+  resources :items, only: [:index, :new, :create, :show, :edit]
 end

--- a/spec/factories/items.rb
+++ b/spec/factories/items.rb
@@ -1,19 +1,17 @@
 FactoryBot.define do
   factory :item do
-    name                   {Faker::Name.name}
-    introduction           {Faker::Lorem.sentence}
-    price                  {Faker::Number.between(from: 1, to: 9999999)}
-    item_condition_id      {3}
-    preparation_day_id     {2}
-    postage_payer_id       {3}
-    category_id            {6}
-    trading_status_id      {6}
+    name { Faker::Name.name }
+    introduction           { Faker::Lorem.sentence }
+    price                  { Faker::Number.between(from: 1, to: 9_999_999) }
+    item_condition_id      { 3 }
+    preparation_day_id     { 2 }
+    postage_payer_id       { 3 }
+    category_id            { 6 }
+    trading_status_id      { 6 }
     association :user
 
     after(:build) do |item|
       item.image.attach(io: File.open('public/images/test_image.png'), filename: 'test_image.png')
+    end
   end
 end
-end
-
-

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -8,75 +8,75 @@ RSpec.describe Item, type: :model do
   describe '商品の登録' do
     context '商品が出品できる場合' do
       it '全ての値が正しく入力されていれば登録できる' do
-         expect(@item).to be_valid
+        expect(@item).to be_valid
       end
     end
-      
+
     context '商品が出品できない場合' do
-     it '商品名が空では登録できない' do
-       @item.name = nil
-       @item.valid?
-      expect(@item.errors.full_messages).to include("Name can't be blank")
-     end
-     it '商品画像が空では登録できない' do
-      @item.image = nil
-      @item.valid?
-      expect(@item.errors.full_messages).to include("Image can't be blank") 
-    end
+      it '商品名が空では登録できない' do
+        @item.name = nil
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Name can't be blank")
+      end
+      it '商品画像が空では登録できない' do
+        @item.image = nil
+        @item.valid?
+        expect(@item.errors.full_messages).to include("Image can't be blank")
+      end
       it '商品の説明が空では登録できない' do
         @item.introduction = ''
         @item.valid?
         expect(@item.errors.full_messages).to include("Introduction can't be blank")
-      end     
+      end
       it 'カテゴリーが未選択では登録できない' do
         @item.category_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include("Category can't be blank")
-      end     
+      end
       it '商品の状態が未選択では登録できない' do
         @item.item_condition_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include("Item condition can't be blank")
-      end     
+      end
       it '配送料の負担が未選択では登録できない' do
         @item.postage_payer_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include("Postage payer can't be blank")
-      end     
+      end
       it '発送元の地域が未選択では登録できない' do
         @item.trading_status_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include("Trading status can't be blank")
-      end     
+      end
       it '発送までの日数が未選択では登録できない' do
         @item.preparation_day_id = 1
         @item.valid?
         expect(@item.errors.full_messages).to include("Preparation day an't be blank")
-      end     
+      end
       it '販売価格が￥300より少ない時は登録できない' do
         @item.price = 299
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
-      end     
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
+      end
       it '販売価格が¥9,999,999より多い時は登録できない' do
         @item.price = 10_000_000
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
-      end    
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
+      end
       it '価格が空では出品できない' do
         @item.price = nil
         @item.valid?
-      expect(@item.errors.full_messages).to include("Price can't be blank")
+        expect(@item.errors.full_messages).to include("Price can't be blank")
       end
       it 'priceが半角数字でないと出品できない' do
         @item.price = '３００'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
-      it "priceが半角英数混合では登録できないこと" do
-        @item.price = "300dollars"
+      it 'priceが半角英数混合では登録できないこと' do
+        @item.price = '300dollars'
         @item.valid?
-        expect(@item.errors.full_messages).to include("Price Out of setting range")
+        expect(@item.errors.full_messages).to include('Price Out of setting range')
       end
       it 'ユーザーが紐付いていなければ投稿できない' do
         @item.user = nil

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -111,17 +111,19 @@ RSpec.describe User, type: :model do
         @user.valid?
         expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password",
                                                       'Password Password is invalid. Include both letters and numbers')
-        end
+      end
       it 'パスワードが半角英字のみでは登録できない' do
         @user.password = 'aaaaaaaa'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password", "Password Password is invalid. Include both letters and numbers")
+        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password",
+                                                      'Password Password is invalid. Include both letters and numbers')
       end
-       it 'パスワードが全角では登録できない' do
+      it 'パスワードが全角では登録できない' do
         @user.password = '11111111'
         @user.valid?
-        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password", "Password Password is invalid. Include both letters and numbers")
-       end
+        expect(@user.errors.full_messages).to include("Password confirmation doesn't match Password",
+                                                      'Password Password is invalid. Include both letters and numbers')
+      end
     end
   end
 end


### PR DESCRIPTION
#what
商品情報編集画面の設定

#why
商品情報編集機能を実装するため

ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/5a55022af59eab2ec3a5ed42104f670d

 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/136bd8c479cbb37dd5cfca4860fbb352

 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/1524eb5fa5bf763dbda6ea575b8e81fb

何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/777b675234cca4a7bbae879b9b00ce81

 ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の
販売状況に関わらずトップページに遷移する動画
https://gyazo.com/6d8cc04ee27af3b96becb39e462ec0ea

 ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
実装済んでいません。

 ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/87f9631b692abd5d560eb5df31b37afb

 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/1e14104429ac38aedd1543a6b2824479

ご確認宜しくお願い致します。